### PR TITLE
Change input to select word to not be a password

### DIFF
--- a/frontend/src/app/elegir-palabra/elegir-palabra.component.css
+++ b/frontend/src/app/elegir-palabra/elegir-palabra.component.css
@@ -38,3 +38,7 @@ input:disabled {
 label {
   padding-right: 10px;
 }
+
+.secret {
+  -webkit-text-security: disc;
+}

--- a/frontend/src/app/elegir-palabra/elegir-palabra.component.html
+++ b/frontend/src/app/elegir-palabra/elegir-palabra.component.html
@@ -1,21 +1,21 @@
 <div class="center-container">
-  <form class="container">
-    <table>
-      <tr>
-        <th>
-          <div>
-            <label for="palabra-input">Palabra:</label>
-            <input type="password" name="palabra-input" [formControl]="palabra" />
-          </div>
-        </th>
-        <th>
-          <div align="center">
-            <button (click)="jugar()" [disabled]="palabra.value === ''">
-              Jugar
-            </button>
-          </div>
-        </th>
-      </tr>
-    </table>
-  </form>
+    <form class="container">
+        <table>
+            <tr>
+                <th>
+                    <div>
+                        <label for="palabra-input">Palabra:</label>
+                        <input class="secret" type="text" name="palabra-input" [formControl]="palabra" />
+                    </div>
+                </th>
+                <th>
+                    <div align="center">
+                        <button (click)="jugar()" [disabled]="palabra.value === ''">
+                            Jugar
+                        </button>
+                    </div>
+                </th>
+            </tr>
+        </table>
+    </form>
 </div>


### PR DESCRIPTION
The input had the attiribute `type="password"` to hide the characters when typing. But this aproach leads to a subotimal UX because some browser tries to save this word as a password (beacause is maked as one). Changed the type to 'text' and added a css property to hide the word.

In a nuthshell, this popup is removed:
![image](https://github.com/adrielgorosito/Metodologias-agiles-TP/assets/48107910/df356252-93e0-48e4-aa15-7234e8753f20)
